### PR TITLE
Support Java 8 Lambda Expression syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,34 @@ Note: each SockJSRouter will have is own SockJSServer
 
 #### Java API
 
-Here is a short example of how to implement a SockJS endpoint in Java:
+Here is a short example of how to implement a SockJS endpoint in Java 8:
+
+```java
+package controllers;
+
+import play.mvc.*;
+
+import play.sockjs.*;
+
+public class Application extends Controller {
+
+    public static SockJSRouter hello = SockJSRouter.whenReady((in, out) -> {
+
+    	// Log each event received on the socket to the console
+        in.onMessage(System.out::println);
+
+        // When SockJS connection is closed.
+        in.onClose(() -> System.out.println("Disconnected"));
+
+        // Send a single 'Hello!' message
+        out.write("Hello!");
+
+    });
+
+}
+```
+
+The same example in plain old Java:
 
 ```java
 package controllers;

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2,7 +2,7 @@ import sbt._
 import sbt.Keys._
 
 object BuildSettings {
-  val buildVersion = "0.2.2"
+  val buildVersion = "0.2.3"
 
   val buildSettings = Defaults.defaultSettings ++ Seq(
     organization := "com.github.fdimuccio",

--- a/samples/sockjs-protocol-test/app/controllers/ApplicationJ.java
+++ b/samples/sockjs-protocol-test/app/controllers/ApplicationJ.java
@@ -7,7 +7,7 @@ import play.sockjs.*;
 
 public class ApplicationJ extends Controller {
 
-    static class SockJSEcho extends SockJS {
+    static class SockJSEcho implements SockJS {
         public void onReady(SockJS.In in, final SockJS.Out out) {
             in.onMessage(new F.Callback<String>() {
                 public void invoke(String s) {

--- a/samples/sockjs-protocol-test/app/controllers/ApplicationJ8.java
+++ b/samples/sockjs-protocol-test/app/controllers/ApplicationJ8.java
@@ -1,0 +1,37 @@
+package controllers;
+
+import controllers.ApplicationJ.SockJSEcho;
+import play.libs.F;
+import play.mvc.Controller;
+import play.sockjs.CookieCalculator;
+import play.sockjs.SockJS;
+import play.sockjs.SockJSRouter;
+
+public class ApplicationJ8 extends Controller {
+
+	static SockJS echoer = (in, out) -> in.onMessage(s -> out.write(s));
+
+	public static SockJSRouter echo = new SockJSRouter() {
+		@SockJS.Settings(streamingQuota = 4096)
+		public SockJS sockjs() {
+			return echoer;
+		};
+	};
+
+	public static SockJSRouter closed = SockJSRouter.whenReady((in, out) -> out.close());
+
+	public static SockJSRouter disabledWebSocketEcho = new SockJSRouter() {
+		@SockJS.Settings(streamingQuota = 4096, websocket = false)
+		public SockJS sockjs() {
+			return echoer;
+		};
+	};
+
+	public static SockJSRouter cookieNeededEcho = new SockJSRouter() {
+		@SockJS.Settings(streamingQuota = 4096, cookies = CookieCalculator.JSESSIONID.class)
+		public SockJS sockjs() {
+			return echoer;
+		};
+	};
+
+}

--- a/samples/sockjs-protocol-test/conf/routes
+++ b/samples/sockjs-protocol-test/conf/routes
@@ -12,3 +12,8 @@
 ->        /java/close                          controllers.ApplicationJ.closed
 ->        /java/disabled_websocket_echo        controllers.ApplicationJ.disabledWebSocketEcho
 ->        /java/cookie_needed_echo             controllers.ApplicationJ.cookieNeededEcho
+
+->        /java8/echo                           controllers.ApplicationJ8.echo
+->        /java8/close                          controllers.ApplicationJ8.closed
+->        /java8/disabled_websocket_echo        controllers.ApplicationJ8.disabledWebSocketEcho
+->        /java8/cookie_needed_echo             controllers.ApplicationJ8.cookieNeededEcho

--- a/samples/sockjs-protocol-test/project/Build.scala
+++ b/samples/sockjs-protocol-test/project/Build.scala
@@ -8,7 +8,7 @@ object ApplicationBuild extends Build {
     val appVersion      = "1.0"
 
     val main = play.Project(appName, appVersion).settings(
-      libraryDependencies += "com.github.fdimuccio" %% "play2-sockjs" % "0.2.2",
+      libraryDependencies += "com.github.fdimuccio" %% "play2-sockjs" % "0.2.3",
       resolvers += "Maven2 Local" at new File(Path.userHome, ".m2/repository/snapshots").toURI.toURL.toExternalForm,
       resolvers += Resolver.sonatypeRepo("snapshots")
     )

--- a/src/main/java/play/sockjs/SockJS.java
+++ b/src/main/java/play/sockjs/SockJS.java
@@ -5,9 +5,9 @@ import java.util.*;
 
 import play.libs.F.*;
 
-public abstract class SockJS {
+public interface SockJS {
 
-    public abstract void onReady(In in, Out out);
+    public void onReady(In in, Out out);
 
     public static interface Out {
 

--- a/src/main/java/play/sockjs/SockJSRouter.java
+++ b/src/main/java/play/sockjs/SockJSRouter.java
@@ -1,5 +1,15 @@
 package play.sockjs;
 
+import play.sockjs.SockJS.Settings;
+
 public abstract class SockJSRouter extends play.sockjs.core.j.JavaRouter {
+
+	public static SockJSRouter whenReady(final SockJS sockJs) {
+		return new SockJSRouter() {
+			public SockJS sockjs() {
+				return sockJs;
+			}
+		};
+	}
 
 }


### PR DESCRIPTION
With this change you can use this slick syntax:

``` java
public static SockJSRouter hello = SockJSRouter.whenReady((in, out) -> {

    // Log each event received on the socket to the console
    in.onMessage(System.out::println);

    // When SockJS connection is closed.
    in.onClose(() -> System.out.println("Disconnected"));

    // Send a single 'Hello!' message
    out.write("Hello!");

});

```
