### PR TITLE
Upgrade Play to version 2.7.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -42,7 +42,7 @@ pomExtra :=
       </developer>
     </developers>
 
-val play2Version = "2.7.0"
+val play2Version = "2.7.2"
 
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play" % play2Version % "provided->default",


### PR DESCRIPTION
Hi there,

Play Framework version 2.7.1+ brought Play-Json 2.7.1 which somehow broke something since it removed the dependency to `scala-collection-compat`.

References:
https://github.com/playframework/play-json/issues/259
https://github.com/iheartradio/play-swagger/pull/240#issuecomment-461012585
https://github.com/lagom/lagom/issues/1840

Here was the stack trace
```
play.api.http.HttpErrorHandlerExceptions$$anon$1: Execution exception[[CompletionException: java.lang.RuntimeException: java.lang.NoClassDefFoundError: scala/collection/compat/Factory$]]
	at play.api.http.HttpErrorHandlerExceptions$.throwableToUsefulException(HttpErrorHandler.scala:351)
	at play.api.http.HttpErrorHandlerExceptions.throwableToUsefulException(HttpErrorHandler.scala)
	at play.http.DefaultHttpErrorHandler.throwableToUsefulException(DefaultHttpErrorHandler.java:227)
	at play.http.DefaultHttpErrorHandler.onServerError(DefaultHttpErrorHandler.java:182)
	at com.xxx.xxx.configuration.CustomErrorHandler.onServerError(CustomErrorHandler.java:91)
	at play.core.j.JavaHttpErrorHandlerAdapter.$anonfun$onServerError$1(JavaHttpErrorHandlerAdapter.scala:24)
	at play.core.j.JavaHelpers.$anonfun$invokeWithContext$1(JavaHelpers.scala:290)
	at play.core.j.JavaHelpers.withContext(JavaHelpers.scala:302)
	at play.core.j.JavaHelpers.withContext$(JavaHelpers.scala:298)
	at play.core.j.JavaHelpers$.withContext(JavaHelpers.scala:311)
	at play.core.j.JavaHelpers.invokeWithContext(JavaHelpers.scala:289)
	at play.core.j.JavaHelpers.invokeWithContext$(JavaHelpers.scala:284)
	at play.core.j.JavaHelpers$.invokeWithContext(JavaHelpers.scala:311)
	at play.core.j.JavaHttpErrorHandlerAdapter.onServerError(JavaHttpErrorHandlerAdapter.scala:24)
	at play.core.server.AkkaHttpServer$$anonfun$1.applyOrElse(AkkaHttpServer.scala:448)
	at play.core.server.AkkaHttpServer$$anonfun$1.applyOrElse(AkkaHttpServer.scala:446)
	at scala.concurrent.Future.$anonfun$recoverWith$1(Future.scala:417)
	at scala.concurrent.impl.Promise.$anonfun$transformWith$1(Promise.scala:41)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
	at akka.dispatch.BatchingExecutor$AbstractBatch.processBatch(BatchingExecutor.scala:55)
	at akka.dispatch.BatchingExecutor$BlockableBatch.$anonfun$run$1(BatchingExecutor.scala:92)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:85)
	at akka.dispatch.BatchingExecutor$BlockableBatch.run(BatchingExecutor.scala:92)
	at akka.dispatch.TaskInvocation.run(AbstractDispatcher.scala:40)
	at akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask.exec(ForkJoinExecutorConfigurator.scala:49)
	at akka.dispatch.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
	at akka.dispatch.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
	at akka.dispatch.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
	at akka.dispatch.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107)
Caused by: java.util.concurrent.CompletionException: java.lang.RuntimeException: java.lang.NoClassDefFoundError: scala/collection/compat/Factory$
	at java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:292)
	at java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:308)
	at java.util.concurrent.CompletableFuture.uniApply(CompletableFuture.java:593)
	at java.util.concurrent.CompletableFuture$UniApply.tryFire(CompletableFuture.java:577)
	at java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:474)
	at java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:1977)
	at scala.concurrent.java8.FuturesConvertersImpl$CF.apply(FutureConvertersImpl.scala:21)
	at scala.concurrent.java8.FuturesConvertersImpl$CF.apply(FutureConvertersImpl.scala:18)
	at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
	at scala.concurrent.BatchingExecutor$Batch.processBatch$1(BatchingExecutor.scala:67)
	at scala.concurrent.BatchingExecutor$Batch.$anonfun$run$1(BatchingExecutor.scala:82)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:85)
	at scala.concurrent.BatchingExecutor$Batch.run(BatchingExecutor.scala:59)
	at scala.concurrent.Future$InternalCallbackExecutor$.unbatchedExecute(Future.scala:874)
	at scala.concurrent.BatchingExecutor.execute(BatchingExecutor.scala:110)
	at scala.concurrent.BatchingExecutor.execute$(BatchingExecutor.scala:107)
	at scala.concurrent.Future$InternalCallbackExecutor$.execute(Future.scala:872)
	at scala.concurrent.impl.CallbackRunnable.executeWithValue(Promise.scala:72)
	at scala.concurrent.impl.Promise$DefaultPromise.$anonfun$tryComplete$1(Promise.scala:288)
	at scala.concurrent.impl.Promise$DefaultPromise.$anonfun$tryComplete$1$adapted(Promise.scala:288)
	at scala.concurrent.impl.Promise$DefaultPromise.tryComplete(Promise.scala:288)
	at scala.concurrent.Promise.tryFailure(Promise.scala:112)
	at scala.concurrent.Promise.tryFailure$(Promise.scala:112)
	at scala.concurrent.impl.Promise$DefaultPromise.tryFailure(Promise.scala:187)
	at play.api.mvc.Filter$$anon$2$$anonfun$$nestedInanonfun$apply$4$1.applyOrElse(Filters.scala:86)
	at play.api.mvc.Filter$$anon$2$$anonfun$$nestedInanonfun$apply$4$1.applyOrElse(Filters.scala:80)
	... 14 common frames omitted
Caused by: java.lang.RuntimeException: java.lang.NoClassDefFoundError: scala/collection/compat/Factory$
	at play.api.mvc.ActionBuilder$$anon$10.apply(Action.scala:431)
	at play.api.mvc.Action.$anonfun$apply$2(Action.scala:98)
	at scala.concurrent.Future.$anonfun$flatMap$1(Future.scala:307)
	... 13 common frames omitted
Caused by: java.lang.NoClassDefFoundError: scala/collection/compat/Factory$
	at play.sockjs.core.Server.$anonfun$send$14(Server.scala:75)
	at scala.util.Either.fold(Either.scala:191)
	at play.sockjs.core.Server.$anonfun$send$2(Server.scala:75)
	at play.api.mvc.ActionBuilderImpl.invokeBlock(Action.scala:489)
	at play.api.mvc.ActionBuilderImpl.invokeBlock(Action.scala:487)
	at play.api.mvc.ActionBuilder$$anon$10.apply(Action.scala:426)
	... 15 common frames omitted
``` 

Upgrading to latest version of Play Framework (as of today 2.7.2) fix the problem (tested locally).